### PR TITLE
Fix issues around incomparable structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Releases
 
+UNRELEASED
+
+* Fixed `T::Struct`'s of different classes returning `-1`; now returning `nil` as is expected of incomparable objects
+* Fixed incomparable attributes of different returning `-1` instead of `nil`
+
 1.0.0
 
 * Initial release: Extracted from [https://bellroy.com/](Bellroy) projects.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Sorbet](https://user-images.githubusercontent.com/2643026/84757714-60be0600-afbc-11ea-8c0e-7da839ea1712.png)
 
-[![Gem Version](https://badge.fury.io/rb/sorbet-struct-comparable.svg)](https://badge.fury.io/rb/sorbet-struct-comparable) ![Continuous Integration](https://github.com/tricycle/sorbet-struct-comparable/workflows/Continuous%20Integration/badge.svg)
+[![Gem Version](https://badge.fury.io/rb/sorbet-struct-comparable.svg)](https://badge.fury.io/rb/sorbet-struct-comparable) ![Continuous Integration](https://github.com/bellroy/sorbet-struct-comparable/workflows/Continuous%20Integration/badge.svg)
 # Making T::Struct's comparable since 2020
 
 If you just want some simple equality checking on your `T::Struct`'s then you've come to the right place.
@@ -67,4 +67,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/tricycle/sorbet-struct-comparable.
+Bug reports and pull requests are welcome on GitHub at https://github.com/bellroy/sorbet-struct-comparable.

--- a/lib/t/struct/acts_as_comparable.rb
+++ b/lib/t/struct/acts_as_comparable.rb
@@ -7,16 +7,19 @@ module T
       extend T::Sig
       include ::Comparable
 
+      EQUAL = 0
       NOT_COMPARABLE = nil
 
-      sig { params(other: Object).returns(Integer) }
+      sig { params(other: Object).returns(T.nilable(Integer)) }
       def <=>(other)
         return NOT_COMPARABLE if other.class != T.unsafe(self).class
 
         T.unsafe(self).class.decorator.props.keys.each do |attribute_key|
           compare_result = T.unsafe(self).send(attribute_key) <=> other.send(attribute_key)
-          return T.cast(compare_result, Integer) if compare_result != EQUAL
+          return T.cast(compare_result, T.nilable(Integer)) if compare_result != EQUAL
         end
+
+        return EQUAL
       end
     end
   end

--- a/lib/t/struct/acts_as_comparable.rb
+++ b/lib/t/struct/acts_as_comparable.rb
@@ -7,24 +7,16 @@ module T
       extend T::Sig
       include ::Comparable
 
-      LESS_THAN_OTHER = -1
-      EQUAL = 0
+      NOT_COMPARABLE = nil
 
       sig { params(other: Object).returns(Integer) }
       def <=>(other)
-        result = EQUAL
-        return LESS_THAN_OTHER if other.class != T.unsafe(self).class
+        return NOT_COMPARABLE if other.class != T.unsafe(self).class
 
-        T.unsafe(self).class.decorator.props.keys.map do |attribute_key|
+        T.unsafe(self).class.decorator.props.keys.each do |attribute_key|
           compare_result = T.unsafe(self).send(attribute_key) <=> other.send(attribute_key)
-          result = if compare_result.nil?
-                    LESS_THAN_OTHER
-                   else
-                     T.cast(compare_result, Integer)
-                   end
-          break if result != EQUAL
+          return T.cast(compare_result, Integer) if compare_result != EQUAL
         end
-        result
       end
     end
   end

--- a/sorbet-struct-comparable.gemspec
+++ b/sorbet-struct-comparable.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['michael.webb@bellroy.com', 'sam@samuelgil.es']
 
   spec.summary       = "Comparable T::Struct's for the equality focused typed Ruby developer."
-  spec.homepage      = 'https://github.com/tricycle/sorbet-struct-comparable'
+  spec.homepage      = 'https://github.com/bellroy/sorbet-struct-comparable'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
 
   spec.metadata['homepage_uri'] = spec.homepage

--- a/spec/lib/t/struct/acts_as_comparable_spec.rb
+++ b/spec/lib/t/struct/acts_as_comparable_spec.rb
@@ -4,6 +4,74 @@
 module T
   class Struct
     describe ActsAsComparable do
+      describe '#<=>' do
+        subject(:three_way_comparison) { struct_a <=> struct_b }
+
+        let(:struct_a) do
+          SorbetStructComparable::Examples::Interest.new(
+            topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+            rating: 10
+          )
+        end
+        let(:struct_b) do
+          SorbetStructComparable::Examples::Interest.new(
+            topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+            rating: 10
+          )
+        end
+
+        context 'when structs are equal' do
+          it { is_expected.to eq 0 }
+        end
+
+        context 'when first struct is lesser than the second' do
+          let(:struct_a) do
+            SorbetStructComparable::Examples::Interest.new(
+              topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+              rating: 9
+            )
+          end
+
+          it { is_expected.to eq -1 }
+        end
+
+        context 'when first struct is greater than the second' do
+          let(:struct_a) do
+            SorbetStructComparable::Examples::Interest.new(
+              topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+              rating: 11
+            )
+          end
+
+          it { is_expected.to eq 1 }
+        end
+
+        context 'when first struct is of a different type to the second' do
+          let(:struct_a) do
+            SorbetStructComparable::Examples::Incomparable.new(
+              my_incomparable_attribute: BigDecimal(22)
+            )
+          end
+
+          it { is_expected.to be_nil }
+        end
+
+        context 'when first struct has an incomparable attribute to the second' do
+          let(:struct_a) do
+            SorbetStructComparable::Examples::Incomparable.new(
+              my_incomparable_attribute: BigDecimal(22)
+            )
+          end
+          let(:struct_b) do
+            SorbetStructComparable::Examples::Incomparable.new(
+              my_incomparable_attribute: ['Hello']
+            )
+          end
+
+          it { is_expected.to be_nil }
+        end
+      end
+
       describe '#==' do
         subject(:comparison) { person_a }
 
@@ -66,7 +134,7 @@ module T
           it { is_expected.to eq person_b }
         end
 
-        context 'when presented with structs that are incomparable' do
+        context 'when presented with structs that have incomparable attributes' do
           let(:person_a) do
             SorbetStructComparable::Examples::Incomparable.new(
               my_incomparable_attribute: BigDecimal(22)


### PR DESCRIPTION
With thanks to @amomchilov for the suggestions on addressing the correctness of the `<=>` operator: https://github.com/bellroy/sorbet-struct-comparable/pull/3

This PR adds additional tests to help cover `<`, `>` and the matter of incomparable structs or incomparable attributes of comparable structs and then with @amomchilov's suggestions gets these tests passing.