### PR TITLE
add support for hash

### DIFF
--- a/lib/t/struct/acts_as_comparable.rb
+++ b/lib/t/struct/acts_as_comparable.rb
@@ -21,6 +21,11 @@ module T
 
         return EQUAL
       end
+
+      sig { returns(Integer) }
+      def hash
+        T.unsafe(self).class.decorator.props.keys.map { |attribute_key| T.unsafe(self).send(attribute_key).hash }.hash
+      end
     end
   end
 end

--- a/spec/lib/t/struct/acts_as_comparable_spec.rb
+++ b/spec/lib/t/struct/acts_as_comparable_spec.rb
@@ -149,6 +149,40 @@ module T
           it { is_expected.not_to eq person_b }
         end
       end
+
+      describe '#hash' do
+        let(:struct_a) do
+          SorbetStructComparable::Examples::Interest.new(
+            topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+            rating: 10
+          )
+        end
+        let(:struct_b) do
+          SorbetStructComparable::Examples::Interest.new(
+            topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+            rating: 10
+          )
+        end
+
+        context 'two equal structs' do
+          it 'should produce the same hash' do
+            expect(struct_a.hash).to eq(struct_b.hash)
+          end
+        end
+
+        context 'two different structs' do
+          let(:struct_b) do
+            SorbetStructComparable::Examples::Interest.new(
+              topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+              rating: 11
+            )
+          end
+
+          it 'should produce different hash results' do
+            expect(struct_a.hash).to_not eq(struct_b.hash)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
It's a bit surprising when equality works but not for hash keys :) We've had to write a few of our own `hash` methods for structs. Seemed like good functionality to add to this gem.