### PR TITLE
Add support for eql? so that Array.uniq properly dedupes

### DIFF
--- a/lib/t/struct/acts_as_comparable.rb
+++ b/lib/t/struct/acts_as_comparable.rb
@@ -22,6 +22,11 @@ module T
         return EQUAL
       end
 
+      sig { params(other: Object).returns(T::Boolean) }
+      def eql?(other)
+        self == other
+      end
+
       sig { returns(Integer) }
       def hash
         T.unsafe(self).class.decorator.props.keys.map { |attribute_key| T.unsafe(self).send(attribute_key).hash }.hash

--- a/spec/lib/t/struct/acts_as_comparable_spec.rb
+++ b/spec/lib/t/struct/acts_as_comparable_spec.rb
@@ -183,6 +183,48 @@ module T
           end
         end
       end
+
+      describe '#eql?' do
+        let(:struct_a) do
+          SorbetStructComparable::Examples::Interest.new(
+            topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+            rating: 10
+          )
+        end
+        let(:struct_b) do
+          SorbetStructComparable::Examples::Interest.new(
+            topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+            rating: 10
+          )
+        end
+
+        context 'two equal structs' do
+          it 'should be equal' do
+            expect(struct_a.eql?(struct_b)).to eq true
+          end
+
+          it 'should dedupe in an array using uniq' do
+            expect([struct_a, struct_b].uniq).to match_array([struct_a])
+          end
+        end
+
+        context 'two different structs' do
+          let(:struct_b) do
+            SorbetStructComparable::Examples::Interest.new(
+              topic: SorbetStructComparable::Examples::Interest::Topic::Walking,
+              rating: 11
+            )
+          end
+
+          it 'should not be equal' do
+            expect(struct_a.eql?(struct_b)).to eq false
+          end
+
+          it 'should not dedupe in an array using uniq' do
+            expect([struct_a, struct_b].uniq).to match_array([struct_a, struct_b])
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I expected `Array.uniq` to dedupe `T::Struct` that `ActsAsComparable`, but it did not! Looks like `Array.uniq` uses `eql?`, [which is slightly different](https://medium.com/@khalidh64/difference-between-eql-equal-in-ruby-2ffa7f073532) than `==`, though it often ends-up being an alias. So, this adds support for `eql?` & also specs the expected `Array.uniq` functionality. I did not override `equal?` since it sounds like that _should_ check the actual object ID.